### PR TITLE
fix: hide url on edit space modal

### DIFF
--- a/components/DraggableItem/DraggableItem.tsx
+++ b/components/DraggableItem/DraggableItem.tsx
@@ -15,6 +15,7 @@ interface Props {
   icon?: string;
   url?: string;
   defaultEditing?: boolean;
+  shouldShowUrl?: boolean;
   onChangeTitle?: (newTitle: string) => void;
   onRemove?: () => void;
 }
@@ -25,6 +26,7 @@ export const DraggableItem: FC<Props> = ({
   title,
   icon,
   url,
+  shouldShowUrl = true,
   defaultEditing = false,
   onChangeTitle,
   onRemove,
@@ -48,15 +50,17 @@ export const DraggableItem: FC<Props> = ({
             'flex-1': isEditing,
           })}
         >
-          <DraggableItemPopover
-            sections={sections}
-            setSections={setSections}
-            sectionId={sectionId}
-            itemId={itemId}
-            url={url}
-            title={title}
-            icon={icon}
-          />
+          {shouldShowUrl ? (
+            <DraggableItemPopover
+              sections={sections}
+              setSections={setSections}
+              sectionId={sectionId}
+              itemId={itemId}
+              url={url}
+              title={title}
+              icon={icon}
+            />
+          ) : null}
 
           <EditableContent
             isEditing={isEditing}

--- a/components/EditSpaceModal/EditSpaceModal.tsx
+++ b/components/EditSpaceModal/EditSpaceModal.tsx
@@ -128,6 +128,7 @@ export const EditSpaceModal: FC<Props> = ({ isEditingSpace, setIsEditingSpace })
                                 url=""
                                 onRemove={() => onRemoveSection(item.id)}
                                 onChangeTitle={(value) => onRenameSection(item.id, value)}
+                                shouldShowUrl={false}
                               />
                             </div>
                           )}


### PR DESCRIPTION
## Changelog
- Hide the edit URL button before the draggable item inside the edit space modal