### PR TITLE
REMO-60: Update default value of new item by active tab data

### DIFF
--- a/components/GoogleSignIn/GoogleSignIn.tsx
+++ b/components/GoogleSignIn/GoogleSignIn.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import { Image } from '../Image';
-import { isExtension } from '@/utils/env';
+import { isExtension } from '@/lib/chromeApi';
 import { useAppContext } from '@/context/AppContext';
 
 export const GoogleSignIn: FC = () => {

--- a/components/HeaderOptions/HeaderOptions.tsx
+++ b/components/HeaderOptions/HeaderOptions.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
 import { WEB_URL } from '@/constants/config';
-import { isExtension } from '@/utils/env';
+import { isExtension } from '@/lib/chromeApi';
 import { EditSpaceModal } from '../EditSpaceModal';
 import { writeFile } from '@/utils/file';
 import { ImportSpaceModal } from '../ImportSpaceModal';

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -1,11 +1,13 @@
 import { Section as SectionType } from '@/types/Resource';
-import React, { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { EditableAccordion } from '../EditableAccordion';
 import { DraggableItem } from '../DraggableItem';
 import { Draggable, Droppable } from 'react-beautiful-dnd';
 import { useEditableContent } from '@/hooks/useEditableContent';
 import { useAppContext } from '@/context/AppContext';
 import { addItem, removeItem, updateItem } from '@/utils/sections/sectionItem';
+import { getDataFromActiveTab } from '@/lib/chromeApi';
+import { isExtension } from '@/utils/env';
 
 interface Props {
   section: SectionType;
@@ -18,6 +20,7 @@ export const Section: FC<Props> = ({ section, onChangeTitle, onRemoveSection }) 
   const {
     name: newItemName,
     setName: setNewItemName,
+    setDefaultName: setItemDefaultName,
     openAdd: openAddNewItem,
   } = useEditableContent();
 
@@ -45,6 +48,18 @@ export const Section: FC<Props> = ({ section, onChangeTitle, onRemoveSection }) 
 
     setSections(newSections);
   };
+
+  useEffect(() => {
+    (async () => {
+      if (!isExtension()) {
+        return;
+      }
+
+      const activeTabData = await getDataFromActiveTab();
+
+      setItemDefaultName(activeTabData.title || '');
+    })();
+  });
 
   return (
     <EditableAccordion

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -6,8 +6,7 @@ import { Draggable, Droppable } from 'react-beautiful-dnd';
 import { useEditableContent } from '@/hooks/useEditableContent';
 import { useAppContext } from '@/context/AppContext';
 import { addItem, removeItem, updateItem } from '@/utils/sections/sectionItem';
-import { getDataFromActiveTab } from '@/lib/chromeApi';
-import { isExtension } from '@/utils/env';
+import { getDataFromActiveTab, isExtension } from '@/lib/chromeApi';
 
 interface Props {
   section: SectionType;

--- a/context/AppContext.tsx
+++ b/context/AppContext.tsx
@@ -3,7 +3,7 @@ import { localStorageKey } from '@/constants/local-storage';
 import { useRemoteData } from '@/hooks/useRemoteData';
 import { Section, Space } from '@/types/Resource';
 import { getCookie } from '@/utils/cookies';
-import { isExtension } from '@/utils/env';
+import { isExtension } from '@/lib/chromeApi';
 import {
   Dispatch,
   FC,

--- a/hooks/useEditableContent.ts
+++ b/hooks/useEditableContent.ts
@@ -2,10 +2,11 @@ import { useState } from 'react';
 
 export const useEditableContent = () => {
   const [name, setName] = useState<string | null>(null);
+  const [defaultName, setDefaultName] = useState('');
 
   const openAdd = () => {
-    setName('');
+    setName(defaultName);
   };
 
-  return { name, setName, openAdd };
+  return { name, setName, setDefaultName, openAdd };
 };

--- a/lib/chromeApi.ts
+++ b/lib/chromeApi.ts
@@ -1,0 +1,21 @@
+import { isExtension } from '../utils/env';
+
+export interface ActiveTabData {
+  url: string;
+  icon: string;
+  title: string;
+}
+
+export const getDataFromActiveTab = async (): Promise<ActiveTabData> => {
+  if (!isExtension()) {
+    return { url: '', icon: '', title: '' };
+  }
+
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+
+  const url = tab?.url || '';
+  const icon = tab?.favIconUrl || '';
+  const title = tab?.title || '';
+
+  return { url, icon, title };
+};

--- a/lib/chromeApi.ts
+++ b/lib/chromeApi.ts
@@ -1,10 +1,12 @@
-import { isExtension } from '../utils/env';
-
 export interface ActiveTabData {
   url: string;
   icon: string;
   title: string;
 }
+
+export const isExtension = () => {
+  return typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id;
+};
 
 export const getDataFromActiveTab = async (): Promise<ActiveTabData> => {
   if (!isExtension()) {

--- a/lib/gapi.ts
+++ b/lib/gapi.ts
@@ -1,6 +1,6 @@
 import { cookieKey } from '@/constants/cookies';
 import { removeCookie } from '../utils/cookies';
-import { isExtension } from '@/utils/env';
+import { isExtension } from '@/lib/chromeApi';
 import { getAccessToken } from './googleDrive';
 import { localStorageKey } from '@/constants/local-storage';
 

--- a/lib/googleDrive.ts
+++ b/lib/googleDrive.ts
@@ -1,6 +1,6 @@
 import { cookieKey } from '@/constants/cookies';
 import { getCookie } from '@/utils/cookies';
-import { isExtension } from '@/utils/env';
+import { isExtension } from '@/lib/chromeApi';
 
 export const getAccessToken = () => {
   return new Promise<string>((resolve, reject) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,7 @@ import { NextPageWithLayout } from './_app';
 import { SectionList } from '@/components/SectionList';
 import { GoogleSignIn } from '@/components/GoogleSignIn';
 import { useAppContext } from '@/context/AppContext';
-import { isExtension } from '@/utils/env';
+import { isExtension } from '@/lib/chromeApi';
 import { GoogleApiScript } from '@/components/GoogleApiScript';
 
 const Home: NextPageWithLayout = () => {

--- a/utils/env.ts
+++ b/utils/env.ts
@@ -1,3 +1,0 @@
-export const isExtension = () => {
-  return typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id;
-};

--- a/utils/sections/sectionItem.ts
+++ b/utils/sections/sectionItem.ts
@@ -1,9 +1,8 @@
 import { Section, SectionItem } from '@/types/Resource';
 import { generateId } from '../string';
 import { DropResult } from 'react-beautiful-dnd';
-import { isExtension } from '../env';
+import { isExtension, getDataFromActiveTab } from '@/lib/chromeApi';
 import { getSelfHostedFavicon } from '../apis/getSelfHostedFavicon';
-import { getDataFromActiveTab } from '@/lib/chromeApi';
 
 /**
  * Reorders the items in the sections array based on the provided drop result.

--- a/utils/sections/sectionItem.ts
+++ b/utils/sections/sectionItem.ts
@@ -3,6 +3,7 @@ import { generateId } from '../string';
 import { DropResult } from 'react-beautiful-dnd';
 import { isExtension } from '../env';
 import { getSelfHostedFavicon } from '../apis/getSelfHostedFavicon';
+import { getDataFromActiveTab } from '@/lib/chromeApi';
 
 /**
  * Reorders the items in the sections array based on the provided drop result.
@@ -61,14 +62,10 @@ export const addItem = async (sections: Section[], sectionId: string, name: stri
   };
 
   if (isExtension()) {
-    const queryOptions = { active: true, currentWindow: true };
-
-    const [tab] = await chrome.tabs.query(queryOptions);
-
-    const url = tab?.url || '';
+    const { url, icon } = await getDataFromActiveTab();
 
     newItem.url = url;
-    newItem.icon = await getFaviconFromURL(url);
+    newItem.icon = icon || (await getFaviconFromURL(url));
   }
 
   const newSections = JSON.parse(JSON.stringify(sections));


### PR DESCRIPTION
# Changelog
- Update default value of new item (title, faviconUrl) by active tab data
- Move `isExtension` function to `@/lib/chromeApi`